### PR TITLE
Revert strncpy_s change

### DIFF
--- a/ADLX Wrapper/adlxWrapper.cpp
+++ b/ADLX Wrapper/adlxWrapper.cpp
@@ -152,7 +152,8 @@ extern "C" {
                         cout << "Display name: " << dispName << endl;
 
                         // Make sure not to overflow the provided buffer
-                        strncpy_s(Name, nameLength, dispName, nameLength-1);
+                        strncpy(Name, dispName, nameLength);
+                        Name[nameLength - 1] = '\0'; // Ensure null-termination
                     }
 
                     adlx_uint manufacturerID;


### PR DESCRIPTION
The compiler warning is back... But the access violation exceptions are gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced buffer safety by updating the string copying mechanism to ensure null-termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->